### PR TITLE
Changed the application title displayed to be the same as on Flatseal and in desktop environment applications list.

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -40,11 +40,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "dupot_easy_flatpak");
+    gtk_header_bar_set_title(header_bar, "Easy Flatpak");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "dupot_easy_flatpak");
+    gtk_window_set_title(window, "Easy Flatpak");
   }
 
   gtk_window_set_default_size(window, 1280, 720);


### PR DESCRIPTION
Here is a small pull request to standardize the application name in the application title bar.