### PR TITLE
Fix Nix package runtime integration and read-only user data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run clean stage install uninstall
+.PHONY: run clean install uninstall
 
 PREFIX ?= /usr/local
 DESTDIR ?=
@@ -7,7 +7,6 @@ BINNAME := dupot_easy_flatpak
 SHAREDIR := $(DESTDIR)$(PREFIX)/share
 LIBDIR := $(SHAREDIR)/dupot-easy-flatpak
 BINDIR := $(DESTDIR)$(PREFIX)/bin
-STAGEDIR := $(CURDIR)/.makestage
 PYTHON ?= python3
 
 run:
@@ -15,56 +14,22 @@ run:
 
 clean:
 	find . -type d -name __pycache__ -exec rm -rf {} +
-	rm -rf $(STAGEDIR)
 
-# Stage a patched copy of src/ + export/ so `install` never mutates the
-# tracked repo files.
-stage:
-	rm -rf $(STAGEDIR)
-	mkdir -p $(STAGEDIR)
-	cp -r src $(STAGEDIR)/src
-	cp -r export $(STAGEDIR)/export
-	# `cp` (used by system_api.py to populate the user data dir) preserves
-	# the source mode. Files copied from the Nix store are 0444, so a FRESH
-	# install ends up with a read-only data dir and sqlite refuses to write
-	# on the very first query.
-	sed -i \
-	  -e "s/subprocess.run(\['cp', path_from, path_to\])/subprocess.run(['cp', '--no-preserve=mode', path_from, path_to])/" \
-	  -e "s/subprocess.run(\['cp', '-r',path_from, path_to\])/subprocess.run(['cp', '-r', '--no-preserve=mode', path_from, path_to])/" \
-	  $(STAGEDIR)/src/infrastructure/api/system_api.py
-	# Also repair installations already left read-only: `cp` keeps an
-	# existing destination's mode, so a 0444 data dir wouldn't be fixed by
-	# the change above. This chmod must run before the FIRST write, which is
-	# reset_updated_for_all(), not UpdateDatabaseFromApiUc.
-	sed -i '/^            if should_reset_lastupdate:/i\
-                for root, dirs, files in os.walk(data_path):\
-                    for directory in dirs:\
-                        os.chmod(os.path.join(root, directory), 0o700)\
-                    for file_name in files:\
-                        os.chmod(os.path.join(root, file_name), 0o600)' \
-	  $(STAGEDIR)/src/main.py
-	$(PYTHON) -m py_compile $(STAGEDIR)/src/main.py
-	# Match Gtk.Application's application_id so desktop shells associate the
-	# running Wayland window with the launcher.
-	sed -i 's/StartupWMClass=dupot_easy_flatpak/StartupWMClass=$(APPID)/' \
-	  $(STAGEDIR)/export/flatpak/$(APPID).desktop
-
-install: stage
+install:
 	install -d $(LIBDIR)
-	cp -r $(STAGEDIR)/src/. $(LIBDIR)/
+	cp -r src/. $(LIBDIR)/
 	install -d $(BINDIR)
-	printf '#!/bin/sh\nexec python3 "$(LIBDIR)/main.py" "$$@"\n' > $(BINDIR)/$(BINNAME)
+	printf '#!/bin/sh\nexec "$(PYTHON)" "$(LIBDIR)/main.py" "$$@"\n' > $(BINDIR)/$(BINNAME)
 	chmod 755 $(BINDIR)/$(BINNAME)
-	install -Dm644 $(STAGEDIR)/export/flatpak/$(APPID).desktop $(SHAREDIR)/applications/$(APPID).desktop
-	install -Dm644 $(STAGEDIR)/export/flatpak/$(APPID).appdata.xml $(SHAREDIR)/metainfo/$(APPID).appdata.xml
-	install -Dm644 $(STAGEDIR)/export/flatpak/$(APPID).xml $(SHAREDIR)/mime/packages/$(APPID).xml
-	install -Dm644 $(STAGEDIR)/export/flatpak/16x16.png $(SHAREDIR)/icons/hicolor/16x16/apps/$(APPID).png
-	install -Dm644 $(STAGEDIR)/export/flatpak/24x24.png $(SHAREDIR)/icons/hicolor/24x24/apps/$(APPID).png
-	install -Dm644 $(STAGEDIR)/export/flatpak/32x32.png $(SHAREDIR)/icons/hicolor/32x32/apps/$(APPID).png
-	install -Dm644 $(STAGEDIR)/export/flatpak/48x48.png $(SHAREDIR)/icons/hicolor/48x48/apps/$(APPID).png
-	install -Dm644 $(STAGEDIR)/export/flatpak/64x64.png $(SHAREDIR)/icons/hicolor/64x64/apps/$(APPID).png
-	install -Dm644 $(STAGEDIR)/export/flatpak/512x512.png $(SHAREDIR)/icons/hicolor/512x512/apps/$(APPID).png
-	rm -rf $(STAGEDIR)
+	install -Dm644 export/flatpak/$(APPID).desktop $(SHAREDIR)/applications/$(APPID).desktop
+	install -Dm644 export/flatpak/$(APPID).appdata.xml $(SHAREDIR)/metainfo/$(APPID).appdata.xml
+	install -Dm644 export/flatpak/$(APPID).xml $(SHAREDIR)/mime/packages/$(APPID).xml
+	install -Dm644 export/flatpak/16x16.png $(SHAREDIR)/icons/hicolor/16x16/apps/$(APPID).png
+	install -Dm644 export/flatpak/24x24.png $(SHAREDIR)/icons/hicolor/24x24/apps/$(APPID).png
+	install -Dm644 export/flatpak/32x32.png $(SHAREDIR)/icons/hicolor/32x32/apps/$(APPID).png
+	install -Dm644 export/flatpak/48x48.png $(SHAREDIR)/icons/hicolor/48x48/apps/$(APPID).png
+	install -Dm644 export/flatpak/64x64.png $(SHAREDIR)/icons/hicolor/64x64/apps/$(APPID).png
+	install -Dm644 export/flatpak/512x512.png $(SHAREDIR)/icons/hicolor/512x512/apps/$(APPID).png
 
 uninstall:
 	rm -rf $(LIBDIR)

--- a/export/flatpak/org.dupot.easyflatpak.desktop
+++ b/export/flatpak/org.dupot.easyflatpak.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Easy Flatpak
 Exec=dupot_easy_flatpak %u
-StartupWMClass=dupot_easy_flatpak
+StartupWMClass=org.dupot.easyflatpak
 Type=Application
 Icon=org.dupot.easyflatpak
 Categories=Utility

--- a/src/domain/contract/system_api_contract.py
+++ b/src/domain/contract/system_api_contract.py
@@ -32,6 +32,10 @@ class SystemApiContract(ABC):
         pass
 
     @abstractmethod
+    def make_tree_writable(self, path: str):
+        pass
+
+    @abstractmethod
     def remove_file(self, path: str):
         pass
 
@@ -66,5 +70,4 @@ class SystemApiContract(ABC):
     @abstractmethod
     def get_file_list(self, path: str) -> list[str]:
         pass
-
 

--- a/src/infrastructure/api/flatpak_api.py
+++ b/src/infrastructure/api/flatpak_api.py
@@ -489,12 +489,20 @@ class FlatpakApi(FlatpakApiContract):
 
     def clean_cache(self):
         subprocess.run(
-            self._cmd("run", "--command=fc-cache", "org.dupot.easyflatpak", "-f", "-v"),
+            self.get_clean_cache_call(),
             capture_output=False,
         )
 
     def get_clean_cache_call(self) -> list:
-        return self._cmd("run", "--command=fc-cache", "org.dupot.easyflatpak", "-f", "-v")
+        if self.is_running_flatpak():
+            return self._cmd(
+                "run",
+                "--command=fc-cache",
+                "org.dupot.easyflatpak",
+                "-f",
+                "-v",
+            )
+        return ["fc-cache", "-f", "-v"]
 
     def get_repair_user_call(self) -> list:
         return self._cmd("repair", "--user")
@@ -556,4 +564,3 @@ class FlatpakApi(FlatpakApiContract):
             )
         
         return remote_repo_list
-

--- a/src/infrastructure/api/system_api.py
+++ b/src/infrastructure/api/system_api.py
@@ -55,21 +55,44 @@ class SystemApi(SystemApiContract):
         )
 
     def copy_file(self, path_from: str, path_to: str):
-        self._cp(['cp', path_from, path_to])
+        # Assets installed by Nix live in the immutable store and therefore
+        # have read-only modes.  Runtime copies belong to the user and must be
+        # writable (the SQLite database and installed_version.json are both
+        # updated after the first launch).
+        if os.path.exists(path_to):
+            os.chmod(path_to, 0o600)
+        shutil.copyfile(path_from, path_to)
+        os.chmod(path_to, 0o600)
 
     def copy_dir(self, path_from: str, path_to: str):
-        self._cp(['cp', '-r', path_from, path_to])
+        destination = (
+            os.path.join(path_to, os.path.basename(os.path.normpath(path_from)))
+            if os.path.isdir(path_to)
+            else path_to
+        )
+        if os.path.exists(destination):
+            self.make_tree_writable(destination)
+        shutil.copytree(
+            path_from,
+            destination,
+            dirs_exist_ok=True,
+            copy_function=shutil.copyfile,
+        )
+        self.make_tree_writable(destination)
 
-    def _cp(self, cmd: list):
-        # check=True: a swallowed cp failure here (bad source path, denied
-        # perm, ...) used to leave the destination missing, and the next
-        # sqlite3 connection to it silently created an empty db — surfacing
-        # much later as a confusing "no such table" instead of the real
-        # cause. Re-raise with stderr attached so the real cause is visible.
-        try:
-            subprocess.run(cmd, check=True, capture_output=True, text=True)
-        except subprocess.CalledProcessError as e:
-            raise RuntimeError(f"{' '.join(cmd)} failed: {e.stderr.strip()}") from e
+    def make_tree_writable(self, path: str):
+        """Repair runtime data copied from a read-only package store."""
+        if not os.path.exists(path):
+            return
+        if os.path.isfile(path):
+            os.chmod(path, 0o600)
+            return
+        os.chmod(path, 0o700)
+        for root, directories, files in os.walk(path):
+            for directory in directories:
+                os.chmod(os.path.join(root, directory), 0o700)
+            for file_name in files:
+                os.chmod(os.path.join(root, file_name), 0o600)
  
     def get_datetime_current_timestamp(self) -> int:
         return int(time.time())
@@ -110,4 +133,3 @@ class SystemApi(SystemApiContract):
     def get_file_list(self, path: str) -> list[str]:
         files = os.listdir(path)
         return [file.lower() for file in files]
-

--- a/src/main.py
+++ b/src/main.py
@@ -106,6 +106,12 @@ def main():
         data_path = path_conf.get_data_path()
         print(f"data path is {data_path}")
 
+        # Older Nix packages copied these files from /nix/store with their
+        # 0444 mode. Repair them before the first SQLite/version write. Icon
+        # trees are repaired lazily by copy_dir() when an upgrade copies them.
+        system_api.make_tree_writable(path_conf.get_database_path())
+        system_api.make_tree_writable(path_conf.get_installed_version_path())
+
         # On a fresh install the user data dir has no database yet. Several
         # repositories below (ApiCacheRepository, ...) open it unconditionally
         # via DatabaseApi, and sqlite3.connect() silently creates an empty


### PR DESCRIPTION
This PR fixes EasyFlatpak when installed as a native Nix package.
Issues fixed:
- Prevents EasyFlatpak from trying to run itself through Flatpak when clearing the font cache.
- Fixes the startup error: “app/org.dupot.easyflatpak/x86_64/master not installed”.
- Ensures files copied from the read-only Nix store are writable in the user data directory.
- Automatically repairs permissions for the existing SQLite database and installed_version.json.
- Removes obsolete source-code patching from the Makefile.
- Uses the Python interpreter provided through the Makefile PYTHON variable.
- Sets the correct StartupWMClass directly in the desktop file.
Root cause:
Files from /nix/store have read-only permissions. The Makefile attempted to patch the copy implementation during the build, but its sed expressions no longer matched the current code.
Cache cleanup also always ran EasyFlatpak through Flatpak. This command is invalid when EasyFlatpak is installed as a native Nix package.
Validation:
- All Python sources compile successfully.
- Font-cache commands were tested in native and Flatpak environments.
- Copying and replacing read-only files was tested.
- The Makefile installation was tested through the project’s Nix environment.
- The generated launcher, desktop file, database and version file were verified.
- git diff --check passes.
Existing users should not need to perform any manual permission repair after updating.